### PR TITLE
Fixing "tried to load angular twice" error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "angularjs": "~1.4.1",
+    "angular": "~1.4.1",
     "skeleton": "~2.0.4",
     "angular-mocks": "~1.4.2"
   }


### PR DESCRIPTION
angular-mocks is depending on "angular", which results in angular source appearing twice in the vendors folder, and loaded twice in the view.
