### PR TITLE
Bump electron version to 1.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME=app
-ELECTRON_VERSION=0.28.3
+ELECTRON_VERSION=1.2.2
 OUTPUT_DIR=build
 
 apps: windows windows-64 mac-64 linux linux-64

--- a/main.js
+++ b/main.js
@@ -1,15 +1,19 @@
 'use strict';
 
 var _ = require('lodash');
-var app = require('app');
+var electron = require('electron');
+var app = electron.app;
 var path = require('path');
-var BrowserWindow = require('browser-window');
+var BrowserWindow = electron.BrowserWindow;
 
 // ####################################################
 // ####################################################
 
 // Report crashes to our server.
-require('crash-reporter').start();
+electron.crashReporter.start({
+	companyName: 'YourCompany',
+	submitURL: 'https://your-domain.com/url-to-submit'
+});
 
 var mainWindow = null;
 var options = {
@@ -33,7 +37,7 @@ app.on('window-all-closed', function() {
 
 app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
-  mainWindow.loadUrl(path.join('file://', __dirname, options.views_dir, options.root_view));
+  mainWindow.loadURL(path.join('file://', __dirname, options.views_dir, options.root_view));
   if(options.debug) { mainWindow.openDevTools(); }
   mainWindow.on('closed', function() { mainWindow = null; });
 });


### PR DESCRIPTION
Fixes error when running `npm start`:

```
App threw an error during load
Error: Cannot find module 'app'
    at Module._resolveFilename (module.js:438:15)
    at Function.Module._resolveFilename (/usr/local/lib/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/electron.asar/common/reset-search-paths.js:47:12)
    at Function.Module._load (module.js:386:25)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/sli/spreenauten/electron-angular-boilerplate/main.js:4:11)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
```
